### PR TITLE
[FIX] Sorting the list of tld's in alphabetical order

### DIFF
--- a/tldtest/views.py
+++ b/tldtest/views.py
@@ -12,7 +12,7 @@ class Index(ListView):
         Tutorial for this is on https://learndjango.com/tutorials/django-search-tutorial
         When writing more optimized search things, might be good reference
         """
-        object_list = TLD.objects.all()
+        object_list = TLD.objects.all().order_by('tld')
         return object_list
 
 


### PR DESCRIPTION
Previously, this was just duming the entire database in the webpage.