### PR TITLE
refresh refreshes all

### DIFF
--- a/atlas/atlascreator.py
+++ b/atlas/atlascreator.py
@@ -74,15 +74,14 @@ def dbwriter(intld, stack, measurement):
     if tld.exists():
         primary_key = tld.values_list('pk', flat=True).first()
         db = TLD.objects.get(pk=primary_key)
-        if measurement is not None:
-            if stack == 4:
-                db.atlasv4 = measurement
-                db.save()
-            elif stack == 6:
-                db.atlasv6 = measurement
-                db.save()
-            else:
-                print("Unknown IP version")
+        if stack == 4:
+            db.atlasv4 = measurement
+            db.save()
+        elif stack == 6:
+            db.atlasv6 = measurement
+            db.save()
+        else:
+            print("Unknown IP version")
 
 
 def main():

--- a/atlas/atlascreator.py
+++ b/atlas/atlascreator.py
@@ -69,8 +69,6 @@ def dbwriter(intld, stack, measurement):
         db = Atlas()
         db.unicodetld = intld
         db.stack = stack
-    if measurement is not None:
-        db.measurement = measurement
     db.save()
     tld = TLD.objects.filter(tld=intld)
     if tld.exists():


### PR DESCRIPTION
At this point, the atlas refresh button creates measurements and needs to be called multiple times to re create those measurements.

Now that the RIPE atlas spending limit has been raised, one refresh can re create all measurements. Meaning that this function is obsolete and that refresh can call a complete refresh of all the data.